### PR TITLE
Fix incorrect total calculation in merge function

### DIFF
--- a/src/PaginationMerge.php
+++ b/src/PaginationMerge.php
@@ -47,7 +47,7 @@ class PaginationMerge
         }
 
         $total = array_reduce($paginators, function ($carry, $paginator) {
-            return $paginator->total();
+            return $carry + $paginator->total();
         }, 0);
 
         $perPage = array_reduce($paginators, function ($carry, $paginator) {


### PR DESCRIPTION
## Problem

The `merge()` function in `PaginationMerge.php` incorrectly calculates the total number of items. The `array_reduce` callback was returning only `$paginator->total()` without adding it to the accumulator (`$carry`).

## Impact

This caused the merged paginator to report an incorrect total count - it would only show the total from the last paginator instead of the sum of all paginator totals.

## Solution

Changed the `array_reduce` callback to properly accumulate the total:

```php
// Before (buggy)
return $paginator->total();

// After (fixed)
return $carry + $paginator->total();
```

## Example

If merging two paginators with 100 and 50 items respectively:
- **Before:** Total reported as 50 (last paginator's total)
- **After:** Total correctly reported as 150 (sum of all totals)

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.